### PR TITLE
Version 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Enable `SignBinary` with `PathTooLong` path.
 ### Updated
 - Create `PathTooLongUtils` to prevent `PathTooLongException`
+### Fix
+- Add `+` split with fix `GetInformationalVersion` with `+` in version. (Fix: #67)
 
 ## [1.7.1] / 2023-10-05
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] / 2023-10-05
+### Features
+- Enable `SignBinary` with `PathTooLong` path.
+### Updated
+- Create `PathTooLongUtils` to prevent `PathTooLongException`
+
 ## [1.7.1] / 2023-10-05
 ### Features
 - Prerelease Nuget force to unlist.
@@ -319,6 +325,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.7.2]: ../../compare/1.7.1...1.7.2
 [1.7.1]: ../../compare/1.7.0...1.7.1
 [1.7.0]: ../../compare/1.6.1...1.7.0
 [1.6.1]: ../../compare/1.6.0...1.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.7.2] / 2023-10-05
+## [1.7.2] / 2023-10-05 - 2023-11-18
 ### Features
 - Enable `SignBinary` with `PathTooLong` path.
 ### Updated

--- a/ricaun.Nuke/Extensions/AssemblyExtension.cs
+++ b/ricaun.Nuke/Extensions/AssemblyExtension.cs
@@ -78,7 +78,7 @@ namespace ricaun.Nuke.Extensions
         /// </summary>
         /// <param name="project"></param>
         /// <returns></returns>
-        public static string GetInformationalVersion(this Project project) => project.GetFileVersionInfo()?.ProductVersion;
+        public static string GetInformationalVersion(this Project project) => project.GetFileVersionInfo()?.ProductVersion.Split('+').First();
 
         /// <summary>
         /// GetCompany => CompanyName

--- a/ricaun.Nuke/Extensions/PathTooLongUtils.cs
+++ b/ricaun.Nuke/Extensions/PathTooLongUtils.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.IO;
+
+namespace ricaun.Nuke.Extensions
+{
+    /// <summary>
+    /// PathTooLongUtils
+    /// </summary>
+    public class PathTooLongUtils
+    {
+        /// <summary>
+        /// MAX_PATH
+        /// </summary>
+        public const int MAX_PATH = 260;
+        /// <summary>
+        /// FileMoveToTempUtils
+        /// </summary>
+        public class FileMoveToTemp : IDisposable
+        {
+            private readonly string filePath;
+            private string tempFilePath;
+            /// <summary>
+            /// FileMoveToTempUtils
+            /// </summary>
+            /// <param name="filePath"></param>
+            public FileMoveToTemp(string filePath)
+            {
+                this.filePath = filePath;
+                Initialize();
+            }
+
+            private void Initialize()
+            {
+                if (IsPathTooLong())
+                {
+                    tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetFileName(this.filePath));
+                    File.Move(this.filePath, tempFilePath, true);
+                }
+            }
+
+            /// <summary>
+            /// GetFilePathLong
+            /// </summary>
+            /// <returns></returns>
+            public int GetFilePathLong()
+            {
+                return GetFilePath().Length;
+            }
+
+            /// <summary>
+            /// Check if path is too long
+            /// </summary>
+            /// <returns></returns>
+            public bool IsPathTooLong()
+            {
+                return GetFilePathLong() > MAX_PATH;
+            }
+
+            /// <summary>
+            /// GetFilePath
+            /// </summary>
+            /// <returns></returns>
+            public string GetFilePath()
+            {
+                return tempFilePath ?? filePath;
+            }
+
+            /// <summary>
+            /// Dispose
+            /// </summary>
+            public void Dispose()
+            {
+                if (tempFilePath is null)
+                    return;
+
+                File.Move(tempFilePath, filePath, true);
+            }
+        }
+    }
+}

--- a/ricaun.Nuke/ricaun.Nuke.csproj
+++ b/ricaun.Nuke/ricaun.Nuke.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Nuke</PackageId>
-    <Version>1.7.2-beta</Version>
+    <Version>1.7.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/ricaun.Nuke/ricaun.Nuke.csproj
+++ b/ricaun.Nuke/ricaun.Nuke.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Nuke</PackageId>
-    <Version>1.7.2-alpha</Version>
+    <Version>1.7.2-beta</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/ricaun.Nuke/ricaun.Nuke.csproj
+++ b/ricaun.Nuke/ricaun.Nuke.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Nuke</PackageId>
-    <Version>1.7.1</Version>
+    <Version>1.7.2-alpha</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### Features
- Enable `SignBinary` with `PathTooLong` path.
### Updated
- Create `PathTooLongUtils` to prevent `PathTooLongException`
### Fix
- Add `+` split with fix `GetInformationalVersion` with `+` in version. (Fix: #67)