### PR TITLE
Version 1.8.0

### DIFF
--- a/Build/Build.csproj
+++ b/Build/Build.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>.</NukeRootDirectory>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.8.0]  / 2023-03-11
 ### Updated
 - Update `Nuke.Common` Version = `8.0.0`
+- Force enable `EnableUnsafeBinaryFormatterSerialization` to support `net8.0`.
 
 ## [1.7.4]  / 2023-02-08
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.8.0]  / 2023-03-11
+### Updated
+- Update `Nuke.Common` Version = `8.0.0`
+
 ## [1.7.4]  / 2023-02-08
 ### Features
 - Update `GetInformationalVersion` to find `nupkg` files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,6 +341,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.8.0]: ../../compare/1.7.4...1.8.0
 [1.7.4]: ../../compare/1.7.3...1.7.4
 [1.7.3]: ../../compare/1.7.2...1.7.3
 [1.7.2]: ../../compare/1.7.1...1.7.2

--- a/ricaun.Nuke/Components/IClean.cs
+++ b/ricaun.Nuke/Components/IClean.cs
@@ -14,7 +14,6 @@ namespace ricaun.Nuke.Components
         Target Clean => _ => _
             .Executes(() =>
             {
-                System.AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
                 Solution.ClearSolution(BuildProjectDirectory);
             });
     }

--- a/ricaun.Nuke/Components/IClean.cs
+++ b/ricaun.Nuke/Components/IClean.cs
@@ -14,6 +14,7 @@ namespace ricaun.Nuke.Components
         Target Clean => _ => _
             .Executes(() =>
             {
+                System.AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
                 Solution.ClearSolution(BuildProjectDirectory);
             });
     }

--- a/ricaun.Nuke/Components/IHazTest.cs
+++ b/ricaun.Nuke/Components/IHazTest.cs
@@ -57,7 +57,7 @@ namespace ricaun.Nuke.Components
                         DotNetTasks.DotNetTest(_ => _
                             .SetProjectFile(testProject)
                             .SetConfiguration(configuration)
-                            .SetVerbosity(DotNetVerbosity.Normal)
+                            .SetVerbosity(DotNetVerbosity.normal)
                             .EnableNoBuild()
                             .SetCustomDotNetTestSettings(customDotNetTestSettings)
                             .When(testResults, _ => _

--- a/ricaun.Nuke/Components/Module.cs
+++ b/ricaun.Nuke/Components/Module.cs
@@ -1,0 +1,10 @@
+﻿class Module
+{
+#pragma warning disable CA2255 // The 'ModuleInitializer' attribute should not be used in libraries
+    [System.Runtime.CompilerServices.ModuleInitializer]
+#pragma warning restore CA2255 // The 'ModuleInitializer' attribute should not be used in libraries
+    internal static void Initialize()
+    {
+        System.AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
+    }
+}

--- a/ricaun.Nuke/ricaun.Nuke.csproj
+++ b/ricaun.Nuke/ricaun.Nuke.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Nuke</PackageId>
-    <Version>1.8.0-alpha.1</Version>
+    <Version>1.8.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/ricaun.Nuke/ricaun.Nuke.csproj
+++ b/ricaun.Nuke/ricaun.Nuke.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Nuke</PackageId>
-    <Version>1.7.4</Version>
+    <Version>1.8.0-alpha</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -71,7 +71,7 @@
   <ItemGroup>
     <PackageReference Include="GitVersion.CommandLine" Version="*" />
     <PackageReference Include="NuGet.CommandLine" Version="*" />
-    <PackageReference Include="Nuke.Common" Version="7.0.6" />
+    <PackageReference Include="Nuke.Common" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/ricaun.Nuke/ricaun.Nuke.csproj
+++ b/ricaun.Nuke/ricaun.Nuke.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Nuke</PackageId>
-    <Version>1.8.0-alpha</Version>
+    <Version>1.8.0-alpha.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### Updated
- Update `Nuke.Common` Version = `8.0.0`
- Force enable `EnableUnsafeBinaryFormatterSerialization` to support `net8.0`.