### PR TITLE
Version 1.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.11.3] / 2026-04-16
+### Updated
+- Update packages to fix vulnerabilities in [NuGet.Packaging](https://github.com/advisories/GHSA-g4vj-cjjj-v7hg) and [System.Security.Cryptography.Xml](https://github.com/advisories/GHSA-37gx-xxp4-5rgx) 
+- Update package in `net8` to fix vulnerabilities in [Microsoft.Build.*](https://github.com/advisories/GHSA-w3q9-fxm7-j8fq)
+
 ## [1.11.2] / 2026-03-20 - 2026-03-31
 ### Features
 - Update to support `.sln` and/or `.slnx` in the `Solution` in `net10.0`
@@ -440,6 +445,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.11.3]: ../../compare/1.11.2...1.11.3
 [1.11.2]: ../../compare/1.11.1...1.11.2
 [1.11.1]: ../../compare/1.11.0...1.11.1
 [1.11.0]: ../../compare/1.10.0...1.11.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.2</Version>
+    <Version>1.11.3-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.3-rc</Version>
+    <Version>1.11.3</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.3-alpha</Version>
+    <Version>1.11.3-alpha.1</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.11.3-alpha.1</Version>
+    <Version>1.11.3-rc</Version>
   </PropertyGroup>
 </Project>

--- a/ricaun.Nuke/ricaun.Nuke.csproj
+++ b/ricaun.Nuke/ricaun.Nuke.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <PackageAssemblyVersion></PackageAssemblyVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <Company>ricaun</Company>
     <Authors>Luiz Henrique Cassettari</Authors>
@@ -58,8 +58,16 @@
     <PackageReference Include="Nuke.Common" Version="10.1.0" Condition="$(TargetFramework.StartsWith('net10'))" />
   </ItemGroup>
 
-  <PropertyGroup Condition="!$(Configuration.Contains('Debug'))">
-    <NoWarn>NU1903</NoWarn>
-  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NuGet.Packaging" Version="6.12.*" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.*" Condition="$(TargetFramework.StartsWith('net8'))" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.*" Condition="$(TargetFramework.StartsWith('net10'))" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
+    <PackageReference Include="Microsoft.Build" Version="17.11.*" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.11.*" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.*"  />
+  </ItemGroup>
 
 </Project>

--- a/ricaun.Nuke/ricaun.Nuke.csproj
+++ b/ricaun.Nuke/ricaun.Nuke.csproj
@@ -60,8 +60,8 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Packaging" Version="6.12.*" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.*" Condition="$(TargetFramework.StartsWith('net8'))" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.*" Condition="$(TargetFramework.StartsWith('net10'))" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.*" Condition="$(TargetFramework.StartsWith('net8'))" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.*" Condition="$(TargetFramework.StartsWith('net10'))" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">


### PR DESCRIPTION
### Updated
- Update packages to fix vulnerabilities in [NuGet.Packaging](https://github.com/advisories/GHSA-g4vj-cjjj-v7hg) and [System.Security.Cryptography.Xml](https://github.com/advisories/GHSA-37gx-xxp4-5rgx) 
- Update package in `net8` to fix vulnerabilities in [Microsoft.Build.*](https://github.com/advisories/GHSA-w3q9-fxm7-j8fq)